### PR TITLE
refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,17 @@ ENV	DOMAIN="" \
 # gerneral packages
 RUN apt update \
 	&& apt -y dist-upgrade \
-	&& apt install -y curl gnupg2 apt-transport-https vim ssmtp python2.7 cron \
-	&& apt install -y nginx php7.0-fpm php7.0-mysql  \
+	&& apt install -y \
+		apt-transport-https \
+		cron \
+		curl \
+		gnupg2 \
+		nginx \
+		php7.0-fpm \
+		php7.0-mysql  \
+		python2.7 \
+		ssmtp \
+		vim \
 	&& rm -rf  /var/cache/apt  /var/lib/apt/lists/*
 
 #nginx-aplify installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,11 +44,21 @@ RUN echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/core:/f
 	&& echo "deb http://repo.z-hub.io/z-push:/final/Debian_9.0/ /" >>  /etc/apt/sources.list.d/z-push.list \
 	&& curl http://repo.z-hub.io/z-push:/final/Debian_9.0/Release.key | apt-key add - \
 	&& apt update \
-	&& apt install -y z-push-kopano  z-push-state-sql \
-	&& apt install -y kopano-server-packages kopano-webapp \
-	&& apt install -y kopano-webapp-plugin-filepreviewer kopano-webapp-plugin-files kopano-webapp-plugin-filesbackend-owncloud  \
-	&& apt install -y kopano-webapp-plugin-titlecounter kopano-webapp-plugin-quickitems kopano-webapp-plugin-folderwidgets kopano-webapp-plugin-mdm \
-	&& apt install -y kopano-webapp-plugin-spell-de-de kopano-webapp-plugin-spell-en kopano-webapp-plugin-webappmanual \
+	&& apt install -y \
+		kopano-server-packages \
+		kopano-webapp \
+		kopano-webapp-plugin-filepreviewer \
+		kopano-webapp-plugin-files \
+		kopano-webapp-plugin-filesbackend-owncloud \
+		kopano-webapp-plugin-folderwidgets \
+		kopano-webapp-plugin-mdm \
+		kopano-webapp-plugin-quickitems \
+		kopano-webapp-plugin-spell-de-de \
+		kopano-webapp-plugin-spell-en \
+		kopano-webapp-plugin-titlecounter \
+		kopano-webapp-plugin-webappmanual \
+		z-push-kopano \
+		z-push-state-sql \
 	&& rm -rf  /var/cache/apt  /var/lib/apt/lists/*
 
 # save config files
@@ -56,7 +66,6 @@ RUN mkdir -p /tmp/kopano_default/config/ \
 	&& mkdir -p /tmp/kopano_default/plugins/ \
 	&& cp -r /etc/kopano/* /tmp/kopano_default/config/ \
 	&& cp -r /usr/share/kopano-webapp/plugins/* /tmp/kopano_default/plugins/
-
 
 ADD templates /tmp/templates
 ADD entrypoint.sh /tmp
@@ -66,6 +75,3 @@ RUN ln -snf /usr/share/zoneinfo/$TIMEZONE /etc/localtime && echo $TIMEZONE > /et
 	&& chmod 777 /tmp/entrypoint.sh
 
 ENTRYPOINT ["/tmp/entrypoint.sh"]
-
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,6 @@ RUN echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/core:/f
 	&& echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/files:/final/Debian_9.0/ ./"  >> /etc/apt/sources.list.d/kopano-core.list \
 	&& echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/mdm:/final/Debian_9.0/ ./"  >> /etc/apt/sources.list.d/kopano-core.list \
 	&& echo "deb http://repo.z-hub.io/z-push:/final/Debian_9.0/ /" >>  /etc/apt/sources.list.d/z-push.list \
-	&& curl https://serial:$KOPANO_SERIAL@download.kopano.io/supported/core:/final/Debian_9.0/Release.key | apt-key add - \
-	&& curl https://serial:$KOPANO_SERIAL@download.kopano.io/supported/webapp:/final/Debian_9.0/Release.key | apt-key add - \
-	&& curl https://serial:$KOPANO_SERIAL@download.kopano.io/supported/files:/final/Debian_9.0/Release.key | apt-key add - \
-	&& curl https://serial:$KOPANO_SERIAL@download.kopano.io/supported/mdm:/final/Debian_9.0/Release.key | apt-key add - \
 	&& curl http://repo.z-hub.io/z-push:/final/Debian_9.0/Release.key | apt-key add - \
 	&& apt update \
 	&& apt install -y z-push-kopano  z-push-state-sql \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/core:/f
 	&& echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/webapp:/final/Debian_9.0/ ./"  >> /etc/apt/sources.list.d/kopano-core.list \
 	&& echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/files:/final/Debian_9.0/ ./"  >> /etc/apt/sources.list.d/kopano-core.list \
 	&& echo "deb https://serial:$KOPANO_SERIAL@download.kopano.io/supported/mdm:/final/Debian_9.0/ ./"  >> /etc/apt/sources.list.d/kopano-core.list \
-	&& echo "deb http://repo.z-hub.io/z-push:/final/Ubuntu_16.04/ /" >>  /etc/apt/sources.list.d/z-push.list \
+	&& echo "deb http://repo.z-hub.io/z-push:/final/Debian_9.0/ /" >>  /etc/apt/sources.list.d/z-push.list \
 	&& curl https://serial:$KOPANO_SERIAL@download.kopano.io/supported/core:/final/Debian_9.0/Release.key | apt-key add - \
 	&& curl https://serial:$KOPANO_SERIAL@download.kopano.io/supported/webapp:/final/Debian_9.0/Release.key | apt-key add - \
 	&& curl https://serial:$KOPANO_SERIAL@download.kopano.io/supported/files:/final/Debian_9.0/Release.key | apt-key add - \


### PR DESCRIPTION
Hi,

I've stumbled upon your image quite a while ago already. I'm currently playing with https://github.com/zokradonh/kopano-docker to make it easier to use (implement a general use docker-compose.yml) and needed a bit of distraction in between.

I have refactored some smaller bits in your Dockerfile to make it a bit easier to read. What I am wondering about though is https://github.com/guitarmarx/kopano-image/blob/master/Dockerfile#L72, why are you putting your entrypoint script into /tmp? Also copying example files to /tmp seems a bit strange as well, I would rather put them into a self defined folder, e.g. /root/example-config.

Keep on the good work!